### PR TITLE
Feature/improve queries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,111 @@ m_readme.md
 .elasticbeanstalk/*
 !.elasticbeanstalk/*.cfg.yml
 !.elasticbeanstalk/*.global.yml
+
+# Standard python gitignore
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+# C extensions
+*.so
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+pip-wheel-metadata/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+# Translations
+*.mo
+*.pot
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+# Flask stuff:
+instance/
+.webassets-cache
+# Scrapy stuff:
+.scrapy
+# Sphinx documentation
+docs/_build/
+# PyBuilder
+target/
+# Jupyter Notebook
+.ipynb_checkpoints
+# IPython
+profile_default/
+ipython_config.py
+# pyenv
+.python-version
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow
+__pypackages__/
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+# SageMath parsed files
+*.sage.py
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+# Spyder project settings
+.spyderproject
+.spyproject
+# Rope project settings
+.ropeproject
+# mkdocs documentation
+/site
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+# Pyre type checker
+.pyre/

--- a/src/app/main.py
+++ b/src/app/main.py
@@ -53,9 +53,10 @@ async def search_custom(search: Search):
     elif search.city == None:
         return search_state(search.search, search.state)
     elif search.state == None:
-        return {"error":"City must be accompanied by a state"}
+        return {"error": "City must be accompanied by a state"}
     else:
         return search_city_state(search.search, search.city, search.state)
+
 
 @app.post("/track/")
 async def search_by_track(track: Track):

--- a/src/app/main.py
+++ b/src/app/main.py
@@ -2,7 +2,7 @@ import pandas as pd
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import HTMLResponse
-from .queries import get_all_jobs, description_city_state, description_state, description
+from .queries import get_all_jobs, search_city_state, search_state, search_all_locations
 from .models import Search, Track
 
 app = FastAPI()
@@ -44,16 +44,18 @@ async def search_custom(search: Search):
     Endpoint to return custom search when user specifies
     the location and enters in keywords  
 
-    NOTE: will currently return the same jobs as endpoint /all  
-    We will be updating this later
+    City and state are both optional. However, if a user specifies a city,
+    there must also be a state.
     """
 
     if (search.city == None) and (search.state == None):
-        return description(search.search)
+        return search_all_locations(search.search)
     elif search.city == None:
-        return description_state(search.search, search.state)
+        return search_state(search.search, search.state)
+    elif search.state == None:
+        return {"error":"City must be accompanied by a state"}
     else:
-        return description_city_state(search.search, search.city, search.state)
+        return search_city_state(search.search, search.city, search.state)
 
 @app.post("/track/")
 async def search_by_track(track: Track):

--- a/src/app/main.py
+++ b/src/app/main.py
@@ -2,7 +2,7 @@ import pandas as pd
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import HTMLResponse
-from .queries import get_all_jobs
+from .queries import get_all_jobs, description_city_state, description_state, description
 from .models import Search, Track
 
 app = FastAPI()
@@ -48,9 +48,12 @@ async def search_custom(search: Search):
     We will be updating this later
     """
 
-    all = get_all_jobs()
-    return all
-
+    if (search.city == None) and (search.state == None):
+        return description(search.search)
+    elif search.city == None:
+        return description_state(search.search, search.state)
+    else:
+        return description_city_state(search.search, search.city, search.state)
 
 @app.post("/track/")
 async def search_by_track(track: Track):

--- a/src/app/models.py
+++ b/src/app/models.py
@@ -3,9 +3,11 @@ from pydantic import BaseModel
 
 class Search(BaseModel):
     search: str
-    location: str = None
+    city: str = None
+    state: str = None
 
 
 class Track(BaseModel):
     track: str
-    location: str = None
+    city: str = None
+    state: str = None

--- a/src/app/queries.py
+++ b/src/app/queries.py
@@ -59,10 +59,11 @@ def get_all_jobs():
 
     return reformatted
 
-def description(search):
+def search_all_locations(search):
     """
-    Only matches description
-    Used if user does not provide location
+    Query to use if user does not specify a location
+    Does a multi_match for the search string in the 
+    description and title field
     """
 
     query = json.dumps(
@@ -81,7 +82,15 @@ def description(search):
 
     return reformatted
 
-def description_city_state(search, city, state):
+def search_city_state(search, city, state):
+    """
+    Query to call if user specifies the location 
+    they want to search in. 
+    
+    Currently using "should" clause, so the locations 
+    do not HAVE to match up-
+    will change this later when we get more jobs in.
+    """
 
     query = json.dumps(
         {
@@ -116,7 +125,11 @@ def description_city_state(search, city, state):
 
     return reformatted
 
-def description_state(search, state):
+def search_state(search, state):
+    """
+    Query to use if user just specifies the state
+    that they want to search in
+    """
 
     query = json.dumps(
         {

--- a/src/app/queries.py
+++ b/src/app/queries.py
@@ -52,9 +52,96 @@ def reformat(response_query):
 def get_all_jobs():
     """Simple Elasticsearch query that will return all jobs"""
 
-    # define query
     query = json.dumps({"query": {"match_all": {}}})
 
+    response = connect(query)
+    reformatted = reformat(response)
+
+    return reformatted
+
+def description(search):
+    """
+    Only matches description
+    Used if user does not provide location
+    """
+
+    query = json.dumps(
+        {
+            "query": {
+                "multi_match": {
+                    "query": search,
+                    "fields": ["description", "title"]
+                }
+             }
+        }
+    )
+
+    response = connect(query)
+    reformatted = reformat(response)
+
+    return reformatted
+
+def description_city_state(search, city, state):
+
+    query = json.dumps(
+        {
+            "query": {
+                "bool": {
+                "must": [
+                    {
+                    "multi_match": {
+                    "query": search,
+                    "fields": ["description, ", "title"]
+                    }
+                    }],
+                "should": [
+                    {
+                    "match": {
+                        "location_city": city
+                    }
+                    },
+                    {
+                    "match": {
+                        "location_state": state
+                    }
+                    }
+                ]
+                }
+            }
+        }
+    )
+
+    response = connect(query)
+    reformatted = reformat(response)
+
+    return reformatted
+
+def description_state(search, state):
+
+    query = json.dumps(
+        {
+        "query": {
+            "bool": {
+            "must": [
+                {
+                "multi_match": {
+                "query": search,
+                "fields": ["description", "title"]
+                }
+                }],
+            "should": [
+                {
+                "match": {
+                    "location_state": state
+                }
+                }
+            ]
+            }
+        }
+        }
+    )
+
+    print(query)
     response = connect(query)
     reformatted = reformat(response)
 

--- a/src/app/queries.py
+++ b/src/app/queries.py
@@ -59,6 +59,7 @@ def get_all_jobs():
 
     return reformatted
 
+
 def search_all_locations(search):
     """
     Query to use if user does not specify a location
@@ -69,11 +70,8 @@ def search_all_locations(search):
     query = json.dumps(
         {
             "query": {
-                "multi_match": {
-                    "query": search,
-                    "fields": ["description", "title"]
-                }
-             }
+                "multi_match": {"query": search, "fields": ["description", "title"]}
+            }
         }
     )
 
@@ -81,6 +79,7 @@ def search_all_locations(search):
     reformatted = reformat(response)
 
     return reformatted
+
 
 def search_city_state(search, city, state):
     """
@@ -96,25 +95,18 @@ def search_city_state(search, city, state):
         {
             "query": {
                 "bool": {
-                "must": [
-                    {
-                    "multi_match": {
-                    "query": search,
-                    "fields": ["description, ", "title"]
-                    }
-                    }],
-                "should": [
-                    {
-                    "match": {
-                        "location_city": city
-                    }
-                    },
-                    {
-                    "match": {
-                        "location_state": state
-                    }
-                    }
-                ]
+                    "must": [
+                        {
+                            "multi_match": {
+                                "query": search,
+                                "fields": ["description, ", "title"],
+                            }
+                        }
+                    ],
+                    "should": [
+                        {"match": {"location_city": city}},
+                        {"match": {"location_state": state}},
+                    ],
                 }
             }
         }
@@ -125,6 +117,7 @@ def search_city_state(search, city, state):
 
     return reformatted
 
+
 def search_state(search, state):
     """
     Query to use if user just specifies the state
@@ -133,24 +126,19 @@ def search_state(search, state):
 
     query = json.dumps(
         {
-        "query": {
-            "bool": {
-            "must": [
-                {
-                "multi_match": {
-                "query": search,
-                "fields": ["description", "title"]
+            "query": {
+                "bool": {
+                    "must": [
+                        {
+                            "multi_match": {
+                                "query": search,
+                                "fields": ["description", "title"],
+                            }
+                        }
+                    ],
+                    "should": [{"match": {"location_state": state}}],
                 }
-                }],
-            "should": [
-                {
-                "match": {
-                    "location_state": state
-                }
-                }
-            ]
             }
-        }
         }
     )
 


### PR DESCRIPTION
Adds custom ES queries for the "search" endpoint

Does a full text search over the description and title. 
Location is optional - but if a city is specified, a state also must be specified.
The location match is a "should", so if there aren't jobs that match the search
jobs in other locations will pop up.

We could change this later if we think matching with location is more important
than matching with title/description. Also, it would be cool to implement some kind of
"radius" with the geo location points.
